### PR TITLE
Fix newline handling in lexer comment skipping

### DIFF
--- a/src/lexing_parsing/lexer.ipp
+++ b/src/lexing_parsing/lexer.ipp
@@ -357,7 +357,7 @@ private:
 
       while (_pos < _content.size() - 1 && (peek() != '*' || peek<1>() != '/'))
       {
-        if (_pos == '\n') incrementLineCount();
+        if (peek() == '\n') incrementLineCount();
         ++_pos;
       }
 


### PR DESCRIPTION
## Summary
- fix newline detection while skipping multiline comments

## Testing
- `zpp_test_cpp` *(fails: couldn't download poetry dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68480cc0e9e88320a452f5cc3bceb02f